### PR TITLE
Fix/ball impulse sync

### DIFF
--- a/Assets/Scripts/Network/BallImpulseBroadcaster.cs
+++ b/Assets/Scripts/Network/BallImpulseBroadcaster.cs
@@ -44,7 +44,7 @@ namespace YubiSoccer.Network
 
             var options = new RaiseEventOptions
             {
-                Receivers = ReceiverGroup.All
+                Receivers = ReceiverGroup.Others
             };
             var sendOptions = new SendOptions { Reliability = true };
 

--- a/Assets/Scripts/Network/BallImpulseReceiver.cs
+++ b/Assets/Scripts/Network/BallImpulseReceiver.cs
@@ -20,6 +20,7 @@ namespace YubiSoccer.Network
             public float lift;
             public int seq;
             public double serverTime;
+            public double lag; // 追加: 受信時のラグ(秒)
             public string uniqueKey; // ActorNumber_Seq
         }
 
@@ -68,12 +69,16 @@ namespace YubiSoccer.Network
 
             if (_appliedSeq.Contains(uniqueKey)) return;
 
+            // ラグ計算 (現在時刻 - 送信時刻)
+            double lag = PhotonNetwork.Time - serverTime;
+
             _queue.Enqueue(new QueuedImpulse
             {
                 impulse = impulse,
                 lift = lift,
                 seq = seq,
                 serverTime = serverTime,
+                lag = lag,
                 uniqueKey = uniqueKey
             });
         }
@@ -94,6 +99,17 @@ namespace YubiSoccer.Network
                 if (qi.lift > 0f)
                 {
                     _rb.AddForce(Vector3.up * qi.lift, ForceMode.Impulse);
+                }
+
+                // ラグ補正 (Fast-Forward)
+                // 物理演算を厳密に進めるのは重いため、簡易的に「速度 * 時間」だけ位置を進める近似を行う
+                if (qi.lag > 0)
+                {
+                    // AddForce直後なので velocity は更新されているはずだが、
+                    // ForceMode.Impulse は即座に velocity を変更する。
+                    // 位置補正: P' = P + V * lag
+                    // ※重力の影響などは無視する簡易近似
+                    _rb.position += _rb.velocity * (float)qi.lag;
                 }
 
                 _appliedSeq.Add(qi.uniqueKey);

--- a/Assets/Scripts/PlayerKickController.cs
+++ b/Assets/Scripts/PlayerKickController.cs
@@ -715,7 +715,12 @@ namespace YubiSoccer.Player
             {
                 if (IsMine)
                 {
+                    // ローカルで即座に力を加える (遅延ゼロ)
+                    if (impulse != Vector3.zero) rb.AddForce(impulse, ForceMode.Impulse);
+                    if (lift > 0f) rb.AddForce(Vector3.up * lift, ForceMode.Impulse);
+
                     Vector3 contact = hitPoint;
+                    // 他人だけに送る (Broadcaster側で ReceiverGroup.Others に変更済み)
                     BallImpulseBroadcaster.RaiseImpulse(ballPv.ViewID, impulse, lift, contact);
                 }
             }


### PR DESCRIPTION
## 概要
キック操作時の体感的な反応遅延（通信ラグ）の解消と、再接続時にボール操作が同期されなくなる不具合を修正しました。

## 変更の意図
**1. キック反応遅延の解消**
これまでは「キック操作 → サーバーへイベント送信 → 受信後に力を加える」というフローだったため、往復通信時間（RTT）分の遅延が必ず発生していました。
今回の変更により、**「ローカルで即座に力を加え、他プレイヤーにはイベントを送る」** 方式に変更し、操作した瞬間にボールが飛ぶように改善しました。

**2. 再接続時の同期不具合修正**
プレイヤーが再接続した際、送信するイベントの連番（seq）がリセットされるため、受信側で「すでに処理済みの古いイベント」と誤判定されて無視される問題がありました。
これを修正し、再接続後も正しく操作が反映されるようにしました。

## 主な変更点

### 1. ローカル即時反映 (PlayerKickController.cs)
- キック実行時、`IsMine`（自分）であれば即座に `Rigidbody.AddForce` を適用するように変更。
- これにより、ボタンを押した瞬間にボールが反応するようになります。

### 2. イベント送信先の変更 (BallImpulseBroadcaster.cs)
- 自身ですでに力を加えているため、自分自身にイベントを送ると力が二重にかかってしまいます。
- そのため、Photonのイベント送信先を `ReceiverGroup.All` から `ReceiverGroup.Others`（自分以外）に変更しました。

### 3. ラグ補正の実装 (BallImpulseReceiver.cs)
- 他プレイヤーがイベントを受け取った際、送信時刻と現在時刻の差（ラグ）を計算。
- `Rigidbody.AddForce` した直後に、`ラグ時間 * 速度` 分だけボールの位置を進めることで、送信側のシミュレーション位置に追いつく処理（Fast-Forward）を追加しました。

### 4. 再接続時の判定ロジック修正 (BallImpulseReceiver.cs)
- 受信済みイベントの重複判定を `seq`（連番）のみから、`ActorNumber_Seq`（送信者ID + 連番）の組み合わせに変更。
- これにより、再接続して `seq` が 0 に戻ったプレイヤーからの入力も、別イベントとして正しく処理されるようになりました。

## 確認方法
- ビルドしたクライアント2台（またはエディタとビルド）で接続。
- 片方のプレイヤーがボールをキックした際、その画面で遅延なくボールが飛ぶことを確認。
- もう片方の画面でも、ほぼ同時にボールが飛ぶ（大きな位置ズレがない）ことを確認。
- 一度切断して再接続したプレイヤーがキックした際も、他プレイヤーに正しく同期されることを確認。